### PR TITLE
Enable code coverage; LDFLAGS fix 

### DIFF
--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -9,6 +9,7 @@ jobs:
 
     env:
       FCFLAGS: "-g -O2 --coverage"
+      LDFLAGS: "--coverage"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -7,6 +7,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      FCFLAGS: "-g -O2 --coverage"
+
     steps:
     - uses: actions/checkout@v2
 
@@ -18,3 +21,6 @@ jobs:
 
     - name: Run executable
       run: ./remap
+
+    - name: Report coverage
+      run: bash <(curl -s https://codecov.io/bash)

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,7 +1,7 @@
 FC = @FC@
 LD = @FC@
 FCFLAGS = @FCFLAGS@
-LDFLAGFS= @LDFLAGS@
+LDFLAGS = @LDFLAGS@
 
 
 # Macros


### PR DESCRIPTION
Enables code coverage build (gcov) and upload (codecov.io) for the
github actions runs.

Also fixed a typo in Makefile.in for LDFLAGS.