### PR TITLE
Replace static arrays with allocatables

### DIFF
--- a/src/test_remap_4lvl.F90
+++ b/src/test_remap_4lvl.F90
@@ -9,17 +9,18 @@ program test_remap_4lvl
   ! Local variables
   integer, parameter :: imax=10000000
   integer, parameter :: n0 = 4, n1 = 3
-  real :: h0(imax,n0), x0(imax,n0+1), u0(imax,n0)
-  real :: h1(imax,n1), x1(imax,n1+1), u1(imax,n1), dx1(imax,n1+1)
-!  data u0 /9., 3., -3., -9./   ! Linear profile, 4 at surface to -4 at bottom
-!  data h0 /4*0.75/ ! 4 uniform layers with total depth of 3
-!  data h1 /3*1./   ! 3 uniform layers with total depth of 3
+  real, allocatable :: h0(:,:), x0(:,:), u0(:,:)
+  real, allocatable :: h1(:,:), x1(:,:), u1(:,:), dx1(:,:)
   type(remapping_CS) :: CS !< Remapping control structure
   logical :: answers_2018 !  If true use older, less acccurate expressions.
   integer :: i,k
   real :: err, h_neglect, h_neglect_edge
   logical :: thisTest, v
   real :: a,H
+
+  allocate(h0(imax,n0), x0(imax,n0+1), u0(imax,n0))
+  allocate(h1(imax,n1), x1(imax,n1+1), u1(imax,n1), dx1(imax,n1+1))
+
   a=9.
   H=3.
   !Initialize arrays with test data

--- a/src/test_remap_70lvl.F90
+++ b/src/test_remap_70lvl.F90
@@ -8,16 +8,21 @@ program test_remap_70lvl
   integer, parameter :: imax=100000 ! Number of columns
   integer, parameter :: n0 = 70 ! Number of layers in source grid
   integer, parameter :: n1 = 35 ! Number of layers in target grid
-  real :: h0(imax,n0) ! Source grid 
-  real :: u0(imax,n0) ! Source data
-  real :: h1(imax,n1) ! Target grid
-  real :: u1(imax,n1) ! Target data
+  real, allocatable :: h0(:,:) ! Source grid
+  real, allocatable :: u0(:,:) ! Source data
+  real, allocatable :: h1(:,:) ! Target grid
+  real, allocatable :: u1(:,:) ! Target data
   type(remapping_CS) :: CS ! Remapping control structure
   integer :: i, k ! Indices
   integer, allocatable :: seed(:) ! For getting the same numbers
   integer :: nseed ! size of seed
   real :: rn0(n0), rn1(n1) ! Random number vectors
   real :: h0sum, h1sum ! Total thicknesses of column
+
+  allocate(h0(imax,n0))
+  allocate(u0(imax,n0))
+  allocate(h1(imax,n1))
+  allocate(u1(imax,n1))
 
   ! Create some test data
   call random_seed(size=nseed)


### PR DESCRIPTION
Currently the code is using static arrays for its fields.  This was
causing two issues:

- nvfortran was 64-bit addressing these in BSS, which was causing all
  sorts of minor compilation issues.

- Performance relative to allocated arrays was very different, and
  potentially very misleading compared to production runs.

This patch replaces these arrays with allocatables, which solves the
first problem and addresses the second by presumably producing a more
realistic timing profile.

Runs are notably slower on nvfortran, almost 30-40% slower (6.6s vs
10s).  Have not yet had a look at other compilers.