### PR TITLE
Mersenne + checksums

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -13,6 +13,7 @@ all: test_units test_remap_4lvl test_remap_70lvl
 # Dependencies
 
 COMMON_OBS = MOM_remapping.o MOM_error_handler.o  MOM_string_functions.o \
+             MersenneTwister.o \
              regrid_edge_values.o regrid_solvers.o \
              polynomial_functions.o \
              PCM_functions.o PLM_functions.o PPM_functions.o PQM_functions.o

--- a/src/MersenneTwister.F90
+++ b/src/MersenneTwister.F90
@@ -1,0 +1,214 @@
+! Fortran-95 implementation of the Mersenne Twister 19937, following
+!   the C implementation described below (code mt19937ar-cok.c, dated 2002/2/10),
+!   adapted cosmetically by making the names more general.
+! Users must declare one or more variables of type randomNumberSequence in the calling
+!   procedure which are then initialized using a required seed. If the
+!   variable is not initialized the random numbers will all be 0.
+! For example:
+! program testRandoms
+!   use RandomNumbers
+!   type(randomNumberSequence) :: randomNumbers
+!   integer                    :: i
+!
+!   randomNumbers = new_RandomNumberSequence(seed = 100)
+!   do i = 1, 10
+!     print ('(f12.10, 2x)'), getRandomReal(randomNumbers)
+!   end do
+! end program testRandoms
+!
+! Fortran-95 implementation by
+!   Robert Pincus
+!   NOAA-CIRES Climate Diagnostics Center
+!   Boulder, CO 80305
+!   email: Robert.Pincus@colorado.edu
+!
+! This documentation in the original C program reads:
+! -------------------------------------------------------------
+!    A C-program for MT19937, with initialization improved 2002/2/10.
+!    Coded by Takuji Nishimura and Makoto Matsumoto.
+!    This is a faster version by taking Shawn Cokus's optimization,
+!    Matthe Bellew's simplification, Isaku Wada's real version.
+!
+!    Before using, initialize the state by using init_genrand(seed)
+!    or init_by_array(init_key, key_length).
+!
+!    Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
+!    All rights reserved.
+!
+!    Redistribution and use in source and binary forms, with or without
+!    modification, are permitted provided that the following conditions
+!    are met:
+!
+!      1. Redistributions of source code must retain the above copyright
+!         notice, this list of conditions and the following disclaimer.
+!
+!      2. Redistributions in binary form must reproduce the above copyright
+!         notice, this list of conditions and the following disclaimer in the
+!         documentation and/or other materials provided with the distribution.
+!
+!      3. The names of its contributors may not be used to endorse or promote
+!         products derived from this software without specific prior written
+!         permission.
+!
+!    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+!    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+!    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+!    A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+!    CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+!    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+!    PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+!    PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+!    LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+!    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+!    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+!
+!    Any feedback is very welcome.
+!    http://www.math.keio.ac.jp/matumoto/emt.html
+!    email: matumoto@math.keio.ac.jp
+! -------------------------------------------------------------
+
+module MersenneTwister
+! -------------------------------------------------------------
+  implicit none
+  private
+
+  ! Algorithm parameters
+  ! -------
+  ! Period parameters
+  integer, parameter :: blockSize = 624,         &
+                        M         = 397,         &
+                        MATRIX_A  = -1727483681, & ! constant vector a         (0x9908b0dfUL)
+                        UMASK     = -2147483648_8, & ! most significant w-r bits (0x80000000UL)
+                        LMASK     =  2147483647    ! least significant r bits  (0x7fffffffUL)
+  ! Tempering parameters
+  integer, parameter :: TMASKB= -1658038656, & ! (0x9d2c5680UL)
+                        TMASKC= -272236544     ! (0xefc60000UL)
+  ! -------
+
+  ! The type containing the state variable
+  type randomNumberSequence
+    integer                            :: currentElement ! = blockSize
+    integer, dimension(0:blockSize -1) :: state ! = 0
+  end type randomNumberSequence
+
+  interface new_RandomNumberSequence
+    module procedure initialize_scalar
+  end interface new_RandomNumberSequence
+
+  public :: randomNumberSequence
+  public :: new_RandomNumberSequence, &
+            getRandomReal
+! -------------------------------------------------------------
+contains
+  ! -------------------------------------------------------------
+  ! Private functions
+  ! ---------------------------
+  function mixbits(u, v)
+    integer, intent( in) :: u, v
+    integer              :: mixbits
+
+    mixbits = ior(iand(u, UMASK), iand(v, LMASK))
+  end function mixbits
+  ! ---------------------------
+  function twist(u, v)
+    integer, intent( in) :: u, v
+    integer              :: twist
+
+    ! Local variable
+    integer, parameter, dimension(0:1) :: t_matrix = (/ 0, MATRIX_A /)
+
+    twist = ieor(ishft(mixbits(u, v), -1), t_matrix(iand(v, 1)))
+    twist = ieor(ishft(mixbits(u, v), -1), t_matrix(iand(v, 1)))
+  end function twist
+  ! ---------------------------
+  subroutine nextState(twister)
+    type(randomNumberSequence), intent(inout) :: twister
+
+    ! Local variables
+    integer :: k
+
+    do k = 0, blockSize - M - 1
+      twister%state(k) = ieor(twister%state(k + M), &
+                              twist(twister%state(k), twister%state(k + 1)))
+    end do
+    do k = blockSize - M, blockSize - 2
+      twister%state(k) = ieor(twister%state(k + M - blockSize), &
+                              twist(twister%state(k), twister%state(k + 1)))
+    end do
+    twister%state(blockSize - 1) = ieor(twister%state(M - 1), &
+                                        twist(twister%state(blockSize - 1), twister%state(0)))
+    twister%currentElement = 0
+
+  end subroutine nextState
+  ! ---------------------------
+  elemental function temper(y)
+    integer, intent(in) :: y
+    integer             :: temper
+
+    integer :: x
+
+    ! Tempering
+    x      = ieor(y, ishft(y, -11))
+    x      = ieor(x, iand(ishft(x,  7), TMASKB))
+    x      = ieor(x, iand(ishft(x, 15), TMASKC))
+    temper = ieor(x, ishft(x, -18))
+  end function temper
+  ! -------------------------------------------------------------
+  ! Public (but hidden) functions
+  ! --------------------
+  function initialize_scalar(seed) result(twister)
+    integer,       intent(in   ) :: seed
+    type(randomNumberSequence)                :: twister
+
+    integer :: i
+    ! See Knuth TAOCP Vol2. 3rd Ed. P.106 for multiplier. In the previous versions,
+    !   MSBs of the seed affect only MSBs of the array state[].
+    !   2002/01/09 modified by Makoto Matsumoto
+
+    twister%state(0) = iand(seed, -1)
+    do i = 1,  blockSize - 1 ! ubound(twister%state)
+       twister%state(i) = 1812433253 * ieor(twister%state(i-1), &
+                                            ishft(twister%state(i-1), -30)) + i
+       twister%state(i) = iand(twister%state(i), -1) ! for >32 bit machines
+    end do
+    twister%currentElement = blockSize
+  end function initialize_scalar
+  ! -------------------------------------------------------------
+  ! Public functions
+  ! --------------------
+  function getRandomInt(twister)
+    type(randomNumberSequence), intent(inout) :: twister
+    integer                      :: getRandomInt
+    ! Generate a random integer on the interval [0,0xffffffff]
+    !   Equivalent to genrand_int32 in the C code.
+    !   Fortran doesn't have a type that's unsigned like C does,
+    !   so this is integers in the range -2**31 - 2**31
+    ! All functions for getting random numbers call this one,
+    !   then manipulate the result
+
+    if(twister%currentElement >= blockSize) call nextState(twister)
+
+    getRandomInt = temper(twister%state(twister%currentElement))
+    twister%currentElement = twister%currentElement + 1
+
+  end function getRandomInt
+  ! --------------------
+  function getRandomReal(twister)
+    type(randomNumberSequence), intent(inout) :: twister
+    double precision             :: getRandomReal
+    ! Generate a random number on [0,1]
+    !   Equivalent to genrand_real1 in the C code
+    !   The result is stored as double precision but has 32 bit resolution
+
+    integer :: localInt
+
+    localInt = getRandomInt(twister)
+    if(localInt < 0) then
+      getRandomReal = dble(localInt + 2.0d0**32)/(2.0d0**32 - 1.0d0)
+    else
+      getRandomReal = dble(localInt            )/(2.0d0**32 - 1.0d0)
+    end if
+  end function getRandomReal
+  ! --------------------
+end module MersenneTwister

--- a/src/test_remap_70lvl.F90
+++ b/src/test_remap_70lvl.F90
@@ -4,6 +4,11 @@ program test_remap_70lvl
   use MOM_remapping, only : initialize_remapping
   use MOM_remapping, only : remapping_core_h
   use MOM_remapping, only : remapping_set_param
+  use MersenneTwister, only : randomNumberSequence
+  use MersenneTwister, only : new_randomNumberSequence
+  use MersenneTwister, only : getRandomReal
+
+  implicit none
 
   integer :: twdth=300 ! Tile width (excludes halo but assumes square arrays)
   integer :: halo=4 ! A halo of unused parts of the array
@@ -14,12 +19,12 @@ program test_remap_70lvl
   real, allocatable :: h1(:,:,:) ! Target grid
   real, allocatable :: u1(:,:,:) ! Target data
   type(remapping_CS) :: CS ! Remapping control structure
-  integer :: i, k ! Indices
-  integer, allocatable :: seed(:) ! For getting the same numbers
-  integer :: nseed ! size of seed
+  integer :: i, j, k ! Indices
+  type(randomNumberSequence) :: twister ! Mersenne Twister
   real :: rn0(n0), rn1(n1) ! Random number vectors
   real :: h0sum, h1sum ! Total thicknesses of column
   character(len=32) :: arg ! Command line argument
+  real :: cptime ! CPU time
 
   ! Read tile width and halo from command line arguments (fall back to defaults above)
   select case ( command_argument_count() )
@@ -43,25 +48,18 @@ program test_remap_70lvl
   allocate( u1(1-halo:twdth+halo,1-halo:twdth+halo,n1) )
 
   ! Create some test data
-  call random_seed(size=nseed)
-  allocate( seed(nseed) )
-  seed(:) = 0
+  twister = new_RandomNumberSequence(seed=10)
   do j = 1, twdth
     do i = 1, twdth
-      seed(1) = i
-      call random_seed(put=seed)
       h0sum = 0.
       do k = 1, n0
-        call random_number(rn0)
-        u0(i,j,k) = rn0(k)
-        call random_number(rn0)
-        h0(i,j,k) = rn0(k)
+        u0(i,j,k) = getRandomReal(twister)
+        h0(i,j,k) = getRandomReal(twister)
         h0sum = h0sum + h0(i,j,k)
       enddo
       h1sum = 0.
       do k = 1, n1
-        call random_number(rn1)
-        h1(i,j,k) = rn1(k)
+        h1(i,j,k) = getRandomReal(twister)
         h1sum = h1sum + h1(i,j,k)
       enddo
       ! Adjust target grid to be same total thickness as source grid
@@ -73,76 +71,75 @@ program test_remap_70lvl
 
   ! Remap using PCM
   call initialize_remapping(CS, 'PCM', answers_2018=.false., &
-                            boundary_extrapolation=.false., &
-                            check_reconstruction=.true., check_remapping=.true.)
-  call cpu_time(cptim1)
-  do j = 1, twdth
-    do i = 1, twdth
-      call remapping_core_h(CS, n0, h0(i,j,:), u0(i,j,:), n1, h1(i,j,:), u1(i,j,:), &
-                            h_neglect=1.e-30, h_neglect_edge=1.e-30)
-    enddo
-  enddo
-  call cpu_time(cptim2)
-  print '(''PCM time taken: '',f8.3,'' secs'')', (cptim2 - cptim1)
+                            boundary_extrapolation=.false. )
+  call do_remap(twdth, halo, n0, n1, CS, h0, u0, h1, u1, cptime)
+  print '(''PCM time taken: '',f8.3,'' secs'')', cptime
 
   ! Remap using PLM
   call remapping_set_param(CS, remapping_scheme='PLM')
-  call cpu_time(cptim1)
-  do j = 1, twdth
-    do i = 1, twdth
-      call remapping_core_h(CS, n0, h0(i,j,:), u0(i,j,:), n1, h1(i,j,:), u1(i,j,:), &
-                            h_neglect=1.e-30, h_neglect_edge=1.e-30)
-    enddo
-  enddo
-  call cpu_time(cptim2)
-  print '(''PLM time taken: '',f8.3,'' secs'')', (cptim2 - cptim1)
+  call do_remap(twdth, halo, n0, n1, CS, h0, u0, h1, u1, cptime)
+  print '(''PLM time taken: '',f8.3,'' secs'')', cptime
 
   ! Remap using PPM with explicit edge values
   call remapping_set_param(CS, remapping_scheme='PPM_H4')
-  call cpu_time(cptim1)
-  do j = 1, twdth
-    do i = 1, twdth
-      call remapping_core_h(CS, n0, h0(i,j,:), u0(i,j,:), n1, h1(i,j,:), u1(i,j,:), &
-                            h_neglect=1.e-30, h_neglect_edge=1.e-30)
-    enddo
-  enddo
-  call cpu_time(cptim2)
-  print '(''PPM_H4 time taken: '',f8.3,'' secs'')', (cptim2 - cptim1)
+  call do_remap(twdth, halo, n0, n1, CS, h0, u0, h1, u1, cptime)
+  print '(''PPM_H4 time taken: '',f8.3,'' secs'')', cptime
 
   ! Remap using PPM with implicit edge values
   call remapping_set_param(CS, remapping_scheme='PPM_IH4')
-  call cpu_time(cptim1)
-  do j = 1, twdth
-    do i = 1, twdth
-      call remapping_core_h(CS, n0, h0(i,j,:), u0(i,j,:), n1, h1(i,j,:), u1(i,j,:), &
-                            h_neglect=1.e-30, h_neglect_edge=1.e-30)
-    enddo
-  enddo
-  call cpu_time(cptim2)
-  print '(''PPM_IH4 time taken: '',f8.3,'' secs'')', (cptim2 - cptim1)
+  call do_remap(twdth, halo, n0, n1, CS, h0, u0, h1, u1, cptime)
+  print '(''PPM_IH4 time taken: '',f8.3,'' secs'')', cptime
 
   ! Remap using PQM with IH4-IH3
   call remapping_set_param(CS, remapping_scheme='PQM_IH4IH3')
-  call cpu_time(cptim1)
-  do j = 1, twdth
-    do i = 1, twdth
-      call remapping_core_h(CS, n0, h0(i,j,:), u0(i,j,:), n1, h1(i,j,:), u1(i,j,:), &
-                            h_neglect=1.e-30, h_neglect_edge=1.e-30)
-    enddo
-  enddo
-  call cpu_time(cptim2)
-  print '(''PQM_IH4IH3 time taken: '',f8.3,'' secs'')', (cptim2 - cptim1)
+  call do_remap(twdth, halo, n0, n1, CS, h0, u0, h1, u1, cptime)
+  print '(''PQM_IH4IH3 time taken: '',f8.3,'' secs'')', cptime
 
   ! Remap using PQM with IH6-IH5
   call remapping_set_param(CS, remapping_scheme='PQM_IH6IH5')
-  call cpu_time(cptim1)
-  do j = 1, twdth
-    do i = 1, twdth
-      call remapping_core_h(CS, n0, h0(i,j,:), u0(i,j,:), n1, h1(i,j,:), u1(i,j,:), &
-                            h_neglect=1.e-30, h_neglect_edge=1.e-30)
+  call do_remap(twdth, halo, n0, n1, CS, h0, u0, h1, u1, cptime)
+  print '(''PQM_IH6IH5 time taken: '',f8.3,'' secs'')', cptime
+
+  contains
+
+  ! Remaps u0(h0) to h1 for each column in the computational domain.
+  ! Returns u1(h1) and cputime.
+  subroutine do_remap(twdth, halo, n0, n1, CS, h0, u0, h1, u1, cputime)
+    integer, intent(in) :: twdth !< Width of square computational domain
+    integer, intent(in) :: halo  !< Size of unused halo
+    integer, intent(in) :: n0  !< Number of levels in source grid
+    integer, intent(in) :: n1  !< Number of levels in target grid
+    type(remapping_CS), intent(inout) :: CS ! Remapping control structure
+    real, intent(in) :: h0(1-halo:twdth+halo,1-halo:twdth+halo,n0) !< Source grid
+    real, intent(in) :: u0(1-halo:twdth+halo,1-halo:twdth+halo,n0) !< Source data
+    real, intent(in) :: h1(1-halo:twdth+halo,1-halo:twdth+halo,n1) !< Target grid
+    real, intent(inout) :: u1(1-halo:twdth+halo,1-halo:twdth+halo,n1) !< Target data
+    real, intent(out) :: cputime !< CPU time used
+    ! Local variables
+    integer :: i,j
+    real :: cptim1, cptim2
+
+    ! Production version does not use "checks"
+    call remapping_set_param(CS, check_reconstruction=.false., check_remapping=.false.)
+    call cpu_time(cptim1)
+    do j = 1, twdth
+      do i = 1, twdth
+        call remapping_core_h(CS, n0, h0(i,j,:), u0(i,j,:), n1, h1(i,j,:), u1(i,j,:), &
+                              h_neglect=1.e-30, h_neglect_edge=1.e-30)
+      enddo
     enddo
-  enddo
-  call cpu_time(cptim2)
-  print '(''PQM_IH6IH5 time taken: '',f8.3,'' secs'')', (cptim2 - cptim1)
+    call cpu_time(cptim2)
+    cputime = cptim2 - cptim1
+
+    ! Redo with checks turned on
+    call remapping_set_param(CS, check_reconstruction=.true., check_remapping=.true.)
+    do j = 1, twdth
+      do i = 1, twdth
+        call remapping_core_h(CS, n0, h0(i,j,:), u0(i,j,:), n1, h1(i,j,:), u1(i,j,:), &
+                              h_neglect=1.e-30, h_neglect_edge=1.e-30)
+      enddo
+    enddo
+
+  end subroutine do_remap
 
 end program


### PR DESCRIPTION
This is motivated by a desire to have the same numbers used in the tests by all compilers. This achieves that - the input data are identical but the results do not actually reproduce between compilers.

- Added stripped down copy of the Mersenne Twister copied from FMS
- Also cleanup driver code to use a do_remap() function which does a production mode remap (without checks) and a non-production repeat with checks enabled. The checks are about 10-25% of cost.